### PR TITLE
Dropdown now also loads on initial request

### DIFF
--- a/SudoGenerator/Classes/ProductVersion.cs
+++ b/SudoGenerator/Classes/ProductVersion.cs
@@ -8,10 +8,9 @@ namespace SudoGenerator.Classes
         public string Value { get; set; }
 
         public static readonly ProductVersion OM2012RTM = new ProductVersion("2012-rtm", "2012 RTM");
-        public static readonly ProductVersion OM2012SP1 = new ProductVersion("2012-r2", "2012 SP1");
-        public static readonly ProductVersion OM2012R2 = new ProductVersion("2012-r2", "2012 R2");
+        public static readonly ProductVersion OM2012R2 = new ProductVersion("2012-r2", "2012 SP1 / 2012 R2");
 
-        public static readonly List<ProductVersion> ALL = new List<ProductVersion> { OM2012RTM, OM2012SP1, OM2012R2 };
+        public static readonly List<ProductVersion> ALL = new List<ProductVersion> { OM2012RTM, OM2012R2 };
 
         public ProductVersion(string id, string value)
         {

--- a/SudoGenerator/Controllers/HomeController.cs
+++ b/SudoGenerator/Controllers/HomeController.cs
@@ -8,7 +8,7 @@ namespace SudoGenerator.Controllers
     {
         public IActionResult Index()
         {
-            return View(new Configuration());
+            return View(new Configuration { ProductVersion = "2012-r2" });
         }
 
         public IActionResult Configuration(Configuration configuration)
@@ -31,9 +31,9 @@ namespace SudoGenerator.Controllers
         {
             JsonResult data = null;
 
-            if(type == "os")
+            if (type == "os")
             {
-                if(productVersion == "2012-rtm")
+                if (productVersion == "2012-rtm")
                 {
                     data = Json(OperatingSystem.SC2012RTM);
                 }

--- a/SudoGenerator/Views/Shared/GeneratorForm.cshtml
+++ b/SudoGenerator/Views/Shared/GeneratorForm.cshtml
@@ -50,13 +50,13 @@
 }
 
 <script type="text/javascript">
-    $("#ProductVersion").change(function () {
-        var data = {
+    function loadData(result) {
+        var payload = {
             type: "os",
             ProductVersion: $("#ProductVersion").val()
         };
 
-        $.getJSON('/Home/Data', data, function (result) {
+        $.getJSON('/Home/Data', payload, function (result) {
             var dropdown = $('#OperatingSystem');
             dropdown.empty();
 
@@ -69,5 +69,13 @@
 
             dropdown.prop("disabled", false);
         });
+    }
+
+    $("#ProductVersion").change(function () {
+        loadData();
+    });
+
+    $(function () {
+        loadData()
     });
 </script>


### PR DESCRIPTION
This PR fixes a problem that the operating system was not selectable when 2012 RTM was selected on initial load. Now the os drop down will be populated once the page has been loaded and when the selected value in the product version drop down changes.
